### PR TITLE
Updated podspec name.

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
-  s.name         = "Nimble"
-  s.version      = "0.0.1"
+  s.name         = "Nimble-CoreData"
+  s.version      = "0.0.2"
   s.summary      = "Core Data and iCloud made nimble and fast."
   s.homepage     = "http://github.com/marcosero/Nimble"
   s.license      = 'MIT'
   s.author       = { "Marco Sero" => "marco@marcosero.com" }
-  s.source       = { :git => "http://github.com/marcosero/Nimble", :tag => "0.0.1" }
+  s.source       = { :git => "http://github.com/marcosero/Nimble", :tag => "0.0.2" }
   s.platform     = :ios, '6.0'
   s.source_files = 'Nimble'
   s.framework = 'CoreData'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The answer is quite easy. I needed a Core Data wrapper with these features:
 
 CocoaPods makes our lifes easy :)
 
-    pod "Nimble"
+    pod "Nimble-CoreData"
 
 and then import `Nimble.h` into your prefix file.
 


### PR DESCRIPTION
I've updated the podspec name to address https://github.com/Quick/Nimble/issues/79 . After you merge this, all you'd have to do is pull, do a `git tag 0.0.2 ; tag push --tags`, then `pod trunk push`. 

Let me know if I can clarify anything!

![](http://static.ashfurrow.com/gifs/cat.gif)