### PR TITLE
update shell script adding path for mogenerator

### DIFF
--- a/NimbleDemo.xcodeproj/project.pbxproj
+++ b/NimbleDemo.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mogenerator -m NimbleDemo/Demo/Model/Model.xcdatamodel -H NimbleDemo/Demo/Model/Classes -M NimbleDemo/Demo/Model/Mogenerated --template-var arc=true";
+			shellScript = "/usr/local/bin/mogenerator -m NimbleDemo/Demo/Model/Model.xcdatamodel -H NimbleDemo/Demo/Model/Classes -M NimbleDemo/Demo/Model/Mogenerated --template-var arc=true";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Using /usr/local/bin/mogenerator  instead of just calling mogenerator. This will prevent build failure for those who are not adding it in xcode path.